### PR TITLE
feat: add revert command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,25 @@ $ envelope add local dev true
 $ envelope add prod db_connection https://proddb.com
 $ envelope add prod db_user pg
 $ envelope add prod db_pwd somepwd
-/ DB_CONNECTION=http://localhost:3030 -> https://proddb.com
+$ envelope diff local prod
+# DB_CONNECTION=http://localhost:3030 -> https://proddb.com
 - DB_PWD=somepwd
 - DB_USER=pg
 + DEV=true
+```
+
+### Revert
+Revert a key value of an environment to a previous value
+```diff
+$ envelope add local db_connection http://localhost:3030
+$ envelope add local db_connection http://localhost:2222
+$ envelope add local db_connection http://localhost:3333
+$ envelope list local
+DB_CONNECTION=http://localhost:3333
+$ envelope revert local db_connection
+$ envelope list local
+DB_CONNECTION=http://localhost:2222
+$ envelope revert local db_connection
+$ envelope list local
+DB_CONNECTION=http://localhost:3030
 ```

--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -13,6 +13,7 @@ mod edit;
 mod export;
 mod import;
 mod list;
+mod revert;
 
 #[derive(Subcommand)]
 #[command(infer_subcommands = true)]
@@ -40,6 +41,8 @@ pub enum EnvelopeCmd {
     Import(import::Cmd),
 
     List(list::Cmd),
+
+    Revert(revert::Cmd),
 }
 
 impl EnvelopeCmd {
@@ -59,6 +62,7 @@ impl EnvelopeCmd {
             Self::Edit(edit) => edit.run(&db).await?,
             Self::Import(import) => import.run(&db).await?,
             Self::List(list) => list.run(&db).await?,
+            Self::Revert(revert) => revert.run(&db).await?,
             _ => {}
         }
 

--- a/src/command/client/revert.rs
+++ b/src/command/client/revert.rs
@@ -1,0 +1,22 @@
+use clap::Parser;
+use std::io::Result;
+
+use crate::{db::EnvelopeDb, ops};
+
+/// Revert environment variable
+#[derive(Parser)]
+pub struct Cmd {
+    /// Environment of the key you wish to revert
+    env: String,
+
+    /// Environment key you wish to revert
+    key: String,
+}
+
+impl Cmd {
+    pub async fn run(&self, db: &EnvelopeDb) -> Result<()> {
+        ops::revert(db, &self.env, &self.key).await?;
+
+        Ok(())
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -933,8 +933,7 @@ mod tests {
         db.revert("env1", "key1").await.unwrap();
         assert_eq!(
             db.list_kv_in_env("env1").await.unwrap(),
-            vec![EnvironmentRow::from("env1", "KEY1", "value1")],
-            "env1 should be empty"
+            vec![EnvironmentRow::from("env1", "KEY1", "value1")]
         );
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -910,7 +910,8 @@ mod tests {
                 VALUES
                 ('env1', 'KEY1', 'value1', 0),
                 ('env1', 'KEY1', NULL, 10),
-                ('env1', 'KEY1', 'value2', 100)",
+                ('env1', 'KEY1', 'value2', 100),
+                ('env2', 'KEY1', 'value2', 10)",
         )
         .await
         .unwrap();
@@ -918,6 +919,10 @@ mod tests {
         assert_eq!(
             db.list_kv_in_env("env1").await.unwrap(),
             vec![EnvironmentRow::from("env1", "KEY1", "value2")]
+        );
+        assert_eq!(
+            db.list_kv_in_env("env2").await.unwrap(),
+            vec![EnvironmentRow::from("env2", "KEY1", "value2")]
         );
 
         // this will delete ('env1', 'KEY1', 'value2', 100)
@@ -928,12 +933,22 @@ mod tests {
             vec![],
             "env1 should be empty"
         );
+        assert_eq!(
+            db.list_kv_in_env("env2").await.unwrap(),
+            vec![EnvironmentRow::from("env2", "KEY1", "value2")],
+            "env2 should remain untouched"
+        );
 
         // this will delete ('env1', 'KEY1', NULL, 10)
         db.revert("env1", "key1").await.unwrap();
         assert_eq!(
             db.list_kv_in_env("env1").await.unwrap(),
             vec![EnvironmentRow::from("env1", "KEY1", "value1")]
+        );
+        assert_eq!(
+            db.list_kv_in_env("env2").await.unwrap(),
+            vec![EnvironmentRow::from("env2", "KEY1", "value2")],
+            "env2 should remain untouched"
         );
     }
 }

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -7,7 +7,9 @@ mod duplicate;
 mod edit;
 mod export;
 mod list;
+mod revert;
 
+pub use revert::*;
 pub use diff::*;
 pub use add::*;
 pub use check::*;

--- a/src/ops/revert.rs
+++ b/src/ops/revert.rs
@@ -1,0 +1,9 @@
+use std::io::Result;
+
+use crate::db::EnvelopeDb;
+
+pub async fn revert(db: &EnvelopeDb, env: &str, key: &str) -> Result<()> {
+    db.revert(env, key).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This addresses #37, behavior:

```console
$ envelope add local db_connection http://localhost:3030
$ envelope add local db_connection http://localhost:2222
$ envelope add local db_connection http://localhost:3333
$ envelope list local
DB_CONNECTION=http://localhost:3333
$ envelope revert local db_connection
$ envelope list local
DB_CONNECTION=http://localhost:2222
$ envelope revert local db_connection
$ envelope list local
DB_CONNECTION=http://localhost:3030
```