### PR TITLE
feat: add sorting arg to list command

### DIFF
--- a/src/command/client/list.rs
+++ b/src/command/client/list.rs
@@ -8,12 +8,12 @@ use crate::ops;
 /// Valid sorting types
 #[derive(Debug, Clone, clap::ValueEnum)]
 enum Sort {
-    #[clap(alias = "ka")]
-    KeyAsc,
-    #[clap(alias = "va")]
-    ValueAsc,
-    #[clap(alias = "da")]
-    DateAsc,
+    #[clap(alias = "k")]
+    Key,
+    #[clap(alias = "v")]
+    Value,
+    #[clap(alias = "d")]
+    Date,
     #[clap(alias = "kd")]
     KeyDesc,
     #[clap(alias = "vd")]
@@ -25,11 +25,11 @@ enum Sort {
 impl Sort {
     fn to_str(&self) -> &str {
         match self {
-            Self::DateAsc => "da",
+            Self::Date => "d",
             Self::DateDesc => "dd",
-            Self::KeyAsc => "ka",
+            Self::Key => "k",
             Self::KeyDesc => "kd",
-            Self::ValueAsc => "va",
+            Self::Value => "v",
             Self::ValueDesc => "vd",
         }
     }

--- a/src/command/client/list.rs
+++ b/src/command/client/list.rs
@@ -5,6 +5,36 @@ use std::io::Result;
 use crate::db::{self, EnvelopeDb};
 use crate::ops;
 
+/// Valid sorting types
+#[derive(Debug, Clone, clap::ValueEnum)]
+enum Sort {
+    #[clap(alias = "ka")]
+    KeyAsc,
+    #[clap(alias = "va")]
+    ValueAsc,
+    #[clap(alias = "da")]
+    DateAsc,
+    #[clap(alias = "kd")]
+    KeyDesc,
+    #[clap(alias = "vd")]
+    ValueDesc,
+    #[clap(alias = "dd")]
+    DateDesc,
+}
+
+impl Sort {
+    fn to_str(&self) -> &str {
+        match self {
+            Self::DateAsc => "da",
+            Self::DateDesc => "dd",
+            Self::KeyAsc => "ka",
+            Self::KeyDesc => "kd",
+            Self::ValueAsc => "va",
+            Self::ValueDesc => "vd",
+        }
+    }
+}
+
 /// List saved environments and/or their variables
 #[derive(Parser)]
 pub struct Cmd {
@@ -17,6 +47,10 @@ pub struct Cmd {
 
     #[arg(long, short)]
     truncate: bool,
+
+    /// How envelope should sort result
+    #[arg(long, short, default_value = "da")]
+    sort: Sort,
 }
 
 impl Cmd {
@@ -25,13 +59,13 @@ impl Cmd {
             None => ops::list_envs(&mut io::stdout(), db).await?,
             Some(env) => {
                 if !self.pretty_print {
-                    ops::list_raw(&mut io::stdout(), db, env).await?;
+                    ops::list_raw(&mut io::stdout(), db, env, &self.sort.to_str()).await?;
                 } else {
                     let truncate = match self.truncate {
                         true => db::Truncate::Max(60),
                         false => db::Truncate::None,
                     };
-                    ops::list(db, env, truncate).await?;
+                    ops::table_list(db, env, truncate, &self.sort.to_str()).await?;
                 }
             }
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -313,15 +313,15 @@ impl EnvelopeDb {
             WHERE env = $1
             ORDER BY
                 CASE
-                    WHEN $3 = 'ka' THEN key END,
+                    WHEN $3 = 'k' THEN key END,
                 CASE
                     WHEN $3 = 'kd' THEN key END DESC,
                 CASE
-                    WHEN $3 = 'va' THEN value END,
+                    WHEN $3 = 'v' THEN value END,
                 CASE
                     WHEN $3 = 'vd' THEN value END DESC,
                 CASE
-                    WHEN $3 = 'da' THEN created_at END,
+                    WHEN $3 = 'd' THEN created_at END,
                 CASE
                     WHEN $3 = 'dd' THEN created_at END DESC,
                 created_at ASC",
@@ -901,7 +901,7 @@ mod tests {
                 EnvironmentRow::from("env1", "KEY3", "value3"),
                 EnvironmentRow::from("env1", "KEY4", "value4"),
             ],
-            db.list_kv_in_env_alt("env1", Truncate::None, "ka")
+            db.list_kv_in_env_alt("env1", Truncate::None, "k")
                 .await
                 .unwrap()
         );
@@ -923,7 +923,7 @@ mod tests {
                 EnvironmentRow::from("env1", "KEY2", "value2"),
                 EnvironmentRow::from("env1", "KEY4", "value4"),
             ],
-            db.list_kv_in_env_alt("env1", Truncate::None, "da")
+            db.list_kv_in_env_alt("env1", Truncate::None, "d")
                 .await
                 .unwrap()
         );
@@ -945,7 +945,7 @@ mod tests {
                 EnvironmentRow::from("env1", "KEY3", "value3"),
                 EnvironmentRow::from("env1", "KEY4", "value4"),
             ],
-            db.list_kv_in_env_alt("env1", Truncate::None, "va")
+            db.list_kv_in_env_alt("env1", Truncate::None, "v")
                 .await
                 .unwrap()
         );

--- a/src/ops/edit.rs
+++ b/src/ops/edit.rs
@@ -39,7 +39,7 @@ fn parse(bufr: BufReader<&[u8]>) -> EditorData {
 
 pub async fn edit(db: &EnvelopeDb, env: &str) -> Result<()> {
     let mut kv_list = Vec::new();
-    let envs: Vec<EnvironmentRow> = db.list_kv_in_env_alt(env, Truncate::None).await?;
+    let envs: Vec<EnvironmentRow> = db.list_kv_in_env_alt(env, Truncate::None, "da").await?;
     for env in envs {
         writeln!(&mut kv_list, "{}={}", &env.key, &env.value)?;
     }

--- a/src/ops/list.rs
+++ b/src/ops/list.rs
@@ -45,12 +45,12 @@ impl From<EnvRows> for Table {
     }
 }
 
-pub async fn list(db: &EnvelopeDb, env: &str, truncate: Truncate) -> Result<()> {
+pub async fn table_list(db: &EnvelopeDb, env: &str, truncate: Truncate, sort: &str) -> Result<()> {
     db.env_exists(&env)
         .await
         .map_err(|_| std_err!("env {} does not exist", env))?;
 
-    let envs: Vec<EnvironmentRow> = db.list_kv_in_env_alt(env, truncate).await?;
+    let envs: Vec<EnvironmentRow> = db.list_kv_in_env_alt(env, truncate, sort).await?;
     if !envs.is_empty() {
         Table::from(EnvRows(envs)).printstd();
     }
@@ -58,12 +58,17 @@ pub async fn list(db: &EnvelopeDb, env: &str, truncate: Truncate) -> Result<()> 
     Ok(())
 }
 
-pub async fn list_raw<W: Write>(writer: &mut W, db: &EnvelopeDb, env: &str) -> Result<()> {
+pub async fn list_raw<W: Write>(
+    writer: &mut W,
+    db: &EnvelopeDb,
+    env: &str,
+    sort: &str,
+) -> Result<()> {
     db.env_exists(&env)
         .await
         .map_err(|_| std_err!("env {} does not exist", env))?;
 
-    let envs: Vec<EnvironmentRow> = db.list_kv_in_env_alt(env, Truncate::None).await?;
+    let envs: Vec<EnvironmentRow> = db.list_kv_in_env_alt(env, Truncate::None, sort).await?;
     for env in envs {
         writeln!(writer, "{}={}", &env.key, &env.value)?;
     }


### PR DESCRIPTION
### Sorting Behavior (`--sort <SORT>`)

The `--sort` option controls the ordering of the output. It accepts the following values:  

| Option   | Alias | Description                               |
|----------|-------|-------------------------------------------|
| `key`    | `k`   | Sort by key in ascending order.          |
| `value`  | `v`   | Sort by value in ascending order.        |
| `date`   | `d`   | Sort by creation date in ascending order. |
| `kd`     | —     | Sort by key in descending order.         |
| `vd`     | —     | Sort by value in descending order.       |
| `dd`     | —     | Sort by creation date in descending order (default). |

If no valid sorting option is provided, the default sorting is `dd` (descending by date).