### PR TITLE
Support encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +69,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +114,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -130,6 +161,41 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
 
 [[package]]
 name = "clap"
@@ -238,6 +304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -342,10 +409,17 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 name = "envelope"
 version = "0.5.1"
 dependencies = [
+ "argon2",
+ "chacha20poly1305",
  "clap",
  "prettytable-rs",
+ "rand 0.9.2",
+ "rpassword",
  "sqlx",
+ "tempfile",
+ "thiserror 2.0.17",
  "tokio",
+ "zeroize",
 ]
 
 [[package]]
@@ -353,6 +427,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "etcetera"
@@ -375,6 +459,12 @@ dependencies = [
  "parking",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "find-msvc-tools"
@@ -499,6 +589,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -685,6 +787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +862,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,7 +926,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -857,6 +974,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +1006,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -940,6 +1074,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,14 +1135,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1007,7 +1168,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1016,7 +1187,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1034,9 +1214,20 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1052,11 +1243,34 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1167,7 +1381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1328,7 +1542,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -1366,7 +1580,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -1451,6 +1665,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1638,6 +1865,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1678,6 +1915,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasite"
@@ -1734,6 +1980,24 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -1767,6 +2031,22 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
@@ -1775,7 +2055,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.53.1",
  "windows_i686_msvc 0.53.1",
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
@@ -1787,6 +2067,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1802,6 +2088,12 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
@@ -1814,9 +2106,21 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -1832,6 +2136,12 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
@@ -1841,6 +2151,12 @@ name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1856,6 +2172,12 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
@@ -1868,9 +2190,21 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,16 @@ repository = "https://github.com/mattrighetti/envelope"
 readme = "README.md"
 
 [dependencies]
+argon2 = "0.5.3"
+chacha20poly1305 = "0.10.1"
 clap = { version = "4", features = ["derive"] }
 prettytable-rs = "0.10.0"
-tokio = { version = "1", features = ["macros", "rt"] }
+rand = "0.9.2"
+rpassword = "7.4.0"
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio"] }
+thiserror = "2.0.17"
+tokio = { version = "1", features = ["macros", "rt"] }
+zeroize = "1.8.2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Commands:
   init       Initialize envelope
   import     Import environment variables
   list       List saved environments and/or their variables
+  lock       Encrypt envelope
   revert     Revert environment variable
+  unlock     Decrypt the envelope
   help       Print this message or the help of the given subcommand(s)
 
 Options:
@@ -172,6 +174,29 @@ Checks which environment is currently active
 $ export $(envelope list dev)
 $ envelope check
 dev
+```
+
+### Lock
+Encrypt the envelope database. You will be prompted for a password and a
+confirmation.
+```console
+$ envelope lock
+Password: ********
+Confirm password: ********
+database locked successfully
+```
+
+> [!NOTE]
+>
+> when the database is locked, all other commands
+> will fail until you run `envelope unlock`.
+
+### Unlock
+Decrypt the envelope database with the password you set when locking it.
+```console
+$ envelope unlock
+Password: ********
+database unlocked successfully
 ```
 
 ### Diff

--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -2,8 +2,10 @@ use std::io::Result;
 
 use clap::Subcommand;
 
+use crate::core;
+use crate::core::state::{EnvelopeState, UnlockedEnvelope};
 use crate::db::EnvelopeDb;
-use crate::{ops, std_err};
+use crate::{ops, std_err, utils};
 
 mod add;
 mod delete;
@@ -43,30 +45,78 @@ pub enum EnvelopeCmd {
 
     List(list::Cmd),
 
+    /// Encrypt envelope
+    Lock,
+
     Revert(revert::Cmd),
+
+    /// Decrypt envelope
+    Unlock,
 }
 
 impl EnvelopeCmd {
     pub async fn run(self) -> Result<()> {
-        let db = EnvelopeDb::load(matches!(self, Self::Init))
-            .await
-            .map_err(|e| std_err!("{}", e.to_string()))?;
+        let state = core::state::detect()?;
 
-        match self {
-            Self::Add(add) => add.run(&db).await?,
-            Self::Check => ops::check(&mut std::io::stdout(), &db).await?,
-            Self::Delete(delete) => delete.run(&db).await?,
-            Self::Drop(drop) => drop.run(&db).await?,
-            Self::Duplicate(duplicate) => duplicate.run(&db).await?,
-            Self::Diff(diff) => diff.run(&db).await?,
-            Self::Edit(edit) => edit.run(&db).await?,
-            Self::Import(import) => import.run(&db).await?,
-            Self::History(history) => history.run(&db).await?,
-            Self::List(list) => list.run(&db).await?,
-            Self::Revert(revert) => revert.run(&db).await?,
-            _ => {}
+        match (self, state) {
+            // init: only valid when uninitialized
+            (Self::Init, None) => {
+                core::init().await?;
+                Ok(())
+            }
+            (Self::Init, _) => Err(std_err!("envelope is already initialized")),
+
+            // unlock: only valid when locked
+            (Self::Unlock, Some(EnvelopeState::Locked(env))) => {
+                let password = utils::prompt_password("Password: ")?;
+                env.unlock(&password)?;
+                println!("database unlocked successfully");
+                Ok(())
+            }
+            (Self::Unlock, Some(EnvelopeState::Unlocked)) => {
+                Err(std_err!("envelope is already unlocked"))
+            }
+
+            // lock: only valid when unlocked
+            (Self::Lock, Some(EnvelopeState::Unlocked)) => {
+                let password = utils::prompt_password_confirm()?;
+                let envelope = UnlockedEnvelope::open().await?;
+                envelope.lock(&password)?;
+                println!("database locked successfully");
+                Ok(())
+            }
+            (Self::Lock, Some(EnvelopeState::Locked(_))) => {
+                Err(std_err!("envelope is already locked"))
+            }
+
+            // all other commands: only valid when unlocked
+            (cmd, Some(EnvelopeState::Unlocked)) => {
+                let UnlockedEnvelope { db } = UnlockedEnvelope::open().await?;
+                cmd.run_with_db(&db).await
+            }
+
+            // error cases
+            (_, None) => Err(std_err!("envelope is not initialized")),
+            (_, Some(EnvelopeState::Locked(_))) => {
+                Err(std_err!("envelope is locked - run `envelope unlock` first"))
+            }
         }
+    }
 
-        Ok(())
+    async fn run_with_db(self, db: &EnvelopeDb) -> Result<()> {
+        match self {
+            Self::Add(add) => add.run(db).await,
+            Self::Check => ops::check(&mut std::io::stdout(), db).await,
+            Self::Delete(delete) => delete.run(db).await,
+            Self::Drop(drop) => drop.run(db).await,
+            Self::Duplicate(duplicate) => duplicate.run(db).await,
+            Self::Diff(diff) => diff.run(db).await,
+            Self::Edit(edit) => edit.run(db).await,
+            Self::Import(import) => import.run(db).await,
+            Self::History(history) => history.run(db).await,
+            Self::List(list) => list.run(db).await,
+            Self::Revert(revert) => revert.run(db).await,
+            Self::Init | Self::Lock | Self::Unlock => unreachable!(),
+        }
     }
 }

--- a/src/core/crypto/header.rs
+++ b/src/core/crypto/header.rs
@@ -1,0 +1,304 @@
+use std::io::Read;
+use std::io::Write;
+
+use zeroize::Zeroize;
+
+pub(crate) const MAGIC_NUMBER_LEN: usize = 12;
+pub(crate) const VERSION_LEN: usize = 1;
+pub(crate) const SALT_SIZE: usize = 16;
+pub(crate) const NONCE_SIZE: usize = 24;
+pub(crate) const HEADER_SIZE: usize = MAGIC_NUMBER_LEN + VERSION_LEN + SALT_SIZE + NONCE_SIZE; // 53 bytes
+
+// First 4 bytes are SHA256("envelope")[0..4] to reduce collision risk with other formats.
+// Remaining 8 bytes spell "ENVELOPE" for readability in hex dumps.
+pub(crate) const MAGIC_NUMBER: &[u8; MAGIC_NUMBER_LEN] = b"\x4c\x50\x3c\xa6ENVELOPE";
+pub(crate) const CURRENT_VERSION: u8 = 1;
+
+/// Header for encrypted envelope files
+#[derive(Debug)]
+pub(crate) struct EnvelopeFileHeader {
+    pub magic_number: [u8; MAGIC_NUMBER_LEN],
+    pub version: u8,
+    pub argon_salt: [u8; SALT_SIZE],
+    pub xchacha_nonce: [u8; NONCE_SIZE],
+}
+
+impl Default for EnvelopeFileHeader {
+    fn default() -> Self {
+        Self {
+            magic_number: *MAGIC_NUMBER,
+            version: CURRENT_VERSION,
+            argon_salt: [0u8; SALT_SIZE],
+            xchacha_nonce: [0u8; NONCE_SIZE],
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FileHeaderError {
+    #[error("wrong header size")]
+    WrongHeaderSize,
+    #[error("wrong magic number")]
+    WrongMagicNumber,
+    #[error("parsing error: {0}")]
+    ParsingError(&'static str),
+}
+
+impl TryFrom<&[u8]> for EnvelopeFileHeader {
+    type Error = FileHeaderError;
+
+    fn try_from(buffer: &[u8]) -> Result<Self, Self::Error> {
+        if buffer.len() != HEADER_SIZE {
+            return Err(FileHeaderError::WrongHeaderSize);
+        }
+
+        let mut reader = buffer;
+
+        let mut magic_number = [0u8; MAGIC_NUMBER.len()];
+        reader
+            .read_exact(&mut magic_number)
+            .map_err(|_| FileHeaderError::ParsingError("magic"))?;
+
+        if &magic_number != MAGIC_NUMBER {
+            return Err(FileHeaderError::WrongMagicNumber);
+        }
+
+        let mut version = [0u8; 1];
+        reader
+            .read_exact(&mut version)
+            .map_err(|_| FileHeaderError::ParsingError("version"))?;
+
+        let mut argon_salt = [0u8; SALT_SIZE];
+        reader
+            .read_exact(&mut argon_salt)
+            .map_err(|_| FileHeaderError::ParsingError("argon_salt"))?;
+
+        let mut xchacha_nonce = [0u8; NONCE_SIZE];
+        reader
+            .read_exact(&mut xchacha_nonce)
+            .map_err(|_| FileHeaderError::ParsingError("xchacha_nonce"))?;
+
+        Ok(EnvelopeFileHeader {
+            magic_number,
+            version: version[0],
+            argon_salt,
+            xchacha_nonce,
+        })
+    }
+}
+
+impl From<&EnvelopeFileHeader> for [u8; HEADER_SIZE] {
+    fn from(header: &EnvelopeFileHeader) -> [u8; HEADER_SIZE] {
+        let mut buffer = [0u8; HEADER_SIZE];
+        let mut writer = &mut buffer[..];
+
+        writer.write_all(&header.magic_number).unwrap();
+        writer.write_all(&[header.version]).unwrap();
+        writer.write_all(&header.argon_salt).unwrap();
+        writer.write_all(&header.xchacha_nonce).unwrap();
+
+        buffer
+    }
+}
+
+impl Drop for EnvelopeFileHeader {
+    fn drop(&mut self) {
+        self.argon_salt.zeroize();
+        self.xchacha_nonce.zeroize();
+    }
+}
+
+impl EnvelopeFileHeader {
+    pub(crate) fn to_bytes(&self) -> [u8; HEADER_SIZE] {
+        <[u8; HEADER_SIZE]>::from(self)
+    }
+
+    /// Returns the associated data (magic + version) for AEAD binding.
+    /// This ensures ciphertext is bound to the header version, preventing
+    /// tampering with the version byte without detection.
+    pub(crate) fn associated_data(&self) -> [u8; MAGIC_NUMBER_LEN + VERSION_LEN] {
+        let mut aad = [0u8; MAGIC_NUMBER_LEN + VERSION_LEN];
+        aad[..MAGIC_NUMBER_LEN].copy_from_slice(&self.magic_number);
+        aad[MAGIC_NUMBER_LEN] = self.version;
+        aad
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct EnvelopeFileHeaderBuilder {
+        buffer: Vec<u8>,
+    }
+
+    impl EnvelopeFileHeaderBuilder {
+        fn new() -> Self {
+            Self {
+                buffer: Vec::with_capacity(HEADER_SIZE),
+            }
+        }
+
+        fn magic(mut self, magic: &[u8]) -> Self {
+            self.buffer.extend_from_slice(magic);
+            self
+        }
+
+        fn version(mut self, version: u8) -> Self {
+            self.buffer.push(version);
+            self
+        }
+
+        fn argon_salt(mut self, salt: &[u8]) -> Self {
+            self.buffer.extend_from_slice(salt);
+            self
+        }
+
+        fn xchacha_nonce(mut self, nonce: &[u8]) -> Self {
+            self.buffer.extend_from_slice(nonce);
+            self
+        }
+
+        fn build(self) -> [u8; HEADER_SIZE] {
+            assert_eq!(self.buffer.len(), HEADER_SIZE, "Header size mismatch");
+            let mut output = [0u8; HEADER_SIZE];
+            output.copy_from_slice(&self.buffer);
+            output
+        }
+    }
+
+    fn create_valid_header_buffer() -> [u8; HEADER_SIZE] {
+        EnvelopeFileHeaderBuilder::new()
+            .magic(MAGIC_NUMBER)
+            .version(CURRENT_VERSION)
+            .argon_salt(&[0x01; SALT_SIZE])
+            .xchacha_nonce(&[0x02; NONCE_SIZE])
+            .build()
+    }
+
+    #[test]
+    fn test_valid_header_parsing() {
+        let buffer = create_valid_header_buffer();
+        let header = EnvelopeFileHeader::try_from(&buffer[..]);
+
+        assert!(header.is_ok());
+        let header = header.unwrap();
+
+        assert_eq!(header.magic_number, *MAGIC_NUMBER);
+        assert_eq!(header.version, CURRENT_VERSION);
+        assert_eq!(header.argon_salt, [0x01; SALT_SIZE]);
+        assert_eq!(header.xchacha_nonce, [0x02; NONCE_SIZE]);
+    }
+
+    #[test]
+    fn test_wrong_header_size_too_small() {
+        let buffer = [0u8; 32]; // Only 32 bytes instead of 53
+        let result = EnvelopeFileHeader::try_from(&buffer[..]);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            FileHeaderError::WrongHeaderSize
+        ));
+    }
+
+    #[test]
+    fn test_wrong_header_size_too_large() {
+        let buffer = [0u8; 128]; // 128 bytes instead of 53
+        let result = EnvelopeFileHeader::try_from(&buffer[..]);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            FileHeaderError::WrongHeaderSize
+        ));
+    }
+
+    #[test]
+    fn test_wrong_magic_number() {
+        let mut buffer = create_valid_header_buffer();
+        buffer[0..12].copy_from_slice(b"WRONG_MAGIC!");
+
+        let result = EnvelopeFileHeader::try_from(&buffer[..]);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            FileHeaderError::WrongMagicNumber
+        ));
+    }
+
+    #[test]
+    fn test_partially_wrong_magic_number() {
+        let mut buffer = create_valid_header_buffer();
+        buffer[11] = b'X'; // Change last byte of magic number
+
+        let result = EnvelopeFileHeader::try_from(&buffer[..]);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            FileHeaderError::WrongMagicNumber
+        ));
+    }
+
+    #[test]
+    fn test_empty_buffer() {
+        let buffer: &[u8] = &[];
+        let result = EnvelopeFileHeader::try_from(buffer);
+
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            FileHeaderError::WrongHeaderSize
+        ));
+    }
+
+    #[test]
+    fn test_all_zeros_except_magic() {
+        let mut buffer = [0u8; HEADER_SIZE];
+        buffer[0..12].copy_from_slice(MAGIC_NUMBER);
+
+        let result = EnvelopeFileHeader::try_from(&buffer[..]);
+
+        assert!(result.is_ok());
+        let header = result.unwrap();
+        assert_eq!(header.version, 0);
+        assert_eq!(header.argon_salt, [0; SALT_SIZE]);
+    }
+
+    #[test]
+    fn test_all_ones_except_magic() {
+        let mut buffer = [0xFFu8; HEADER_SIZE];
+        buffer[0..12].copy_from_slice(MAGIC_NUMBER);
+
+        let result = EnvelopeFileHeader::try_from(&buffer[..]);
+
+        assert!(result.is_ok());
+        let header = result.unwrap();
+        assert_eq!(header.version, 0xFF);
+        assert_eq!(header.argon_salt, [0xFF; SALT_SIZE]);
+    }
+
+    #[test]
+    fn test_boundary_values() {
+        let mut buffer = create_valid_header_buffer();
+        buffer[12] = u8::MAX; // version = 255
+
+        let result = EnvelopeFileHeader::try_from(&buffer[..]);
+
+        assert!(result.is_ok());
+        let header = result.unwrap();
+        assert_eq!(header.version, u8::MAX);
+    }
+
+    #[test]
+    fn test_roundtrip_with_to_bytes() {
+        let original_buffer = create_valid_header_buffer();
+        let header = EnvelopeFileHeader::try_from(&original_buffer[..]).unwrap();
+        let serialized = header.to_bytes();
+
+        assert_eq!(original_buffer, serialized);
+    }
+}

--- a/src/core/crypto/mod.rs
+++ b/src/core/crypto/mod.rs
@@ -1,0 +1,459 @@
+use std::io::Result;
+
+use argon2::{Argon2, Params};
+use chacha20poly1305::{
+    XChaCha20Poly1305,
+    aead::{Aead, KeyInit, Payload},
+};
+use rand::RngCore;
+use zeroize::Zeroizing;
+
+use crate::std_err;
+use header::EnvelopeFileHeader;
+
+pub(crate) mod header;
+
+// Argon2id parameters for key derivation.
+//
+// References:
+// - OWASP Password Storage Cheat Sheet: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
+// - RFC 9106 (Argon2): https://www.rfc-editor.org/rfc/rfc9106.html
+const KIB: u32 = 1 << 10;
+const KEY_LEN: usize = 32; // 256-bit key for XChaCha20-Poly1305
+
+#[cfg(not(test))]
+const ARGON_MEMORY_KIB: u32 = 256; // 256 KiB memory cost
+#[cfg(not(test))]
+const ARGON_TIME_COST: u32 = 3; // 3 iterations
+#[cfg(not(test))]
+const ARGON_PARALLELISM: u32 = 8; // 8 parallel threads
+
+// Use minimal Argon2 params in tests for speed
+#[cfg(test)]
+const ARGON_MEMORY_KIB: u32 = 8; // 8 KiB
+#[cfg(test)]
+const ARGON_TIME_COST: u32 = 1; // 1 iteration
+#[cfg(test)]
+const ARGON_PARALLELISM: u32 = 1; // 1 thread
+
+fn derive_key(password: &[u8], salt: &[u8]) -> Result<Zeroizing<Vec<u8>>> {
+    let params = Params::new(
+        ARGON_MEMORY_KIB * KIB,
+        ARGON_TIME_COST,
+        ARGON_PARALLELISM,
+        Some(KEY_LEN),
+    )
+    .map_err(|e| std_err!("key derivation failed: {}", e))?;
+    let argon2 = Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
+
+    let mut key_bytes = Zeroizing::new(vec![0u8; KEY_LEN]);
+    argon2
+        .hash_password_into(password, salt, &mut key_bytes)
+        .map_err(|e| std_err!("key derivation failed: {}", e))?;
+
+    Ok(key_bytes)
+}
+
+pub(crate) fn encrypt(
+    header: &mut EnvelopeFileHeader,
+    blob: &[u8],
+    password: &[u8],
+) -> Result<Vec<u8>> {
+    rand::rng().fill_bytes(&mut header.argon_salt);
+    rand::rng().fill_bytes(&mut header.xchacha_nonce);
+
+    let key = derive_key(password, &header.argon_salt)?;
+    let aead = XChaCha20Poly1305::new(key.as_slice().into());
+    let aad = header.associated_data();
+    let ciphertext = aead
+        .encrypt(
+            header.xchacha_nonce.as_ref().into(),
+            Payload {
+                msg: blob,
+                aad: &aad,
+            },
+        )
+        .map_err(|e| std_err!("encryption failed: {}", e))?;
+
+    Ok(ciphertext)
+}
+
+pub(crate) fn decrypt(
+    blob: &[u8],
+    header: &EnvelopeFileHeader,
+    password: &[u8],
+) -> Result<Vec<u8>> {
+    if header.version != header::CURRENT_VERSION {
+        return Err(std_err!(
+            "unsupported envelope version: {} (expected {})",
+            header.version,
+            header::CURRENT_VERSION
+        ));
+    }
+
+    let key = derive_key(password, &header.argon_salt)?;
+    let aead = XChaCha20Poly1305::new(key.as_slice().into());
+    let aad = header.associated_data();
+    let decrypted = aead
+        .decrypt(
+            header.xchacha_nonce.as_ref().into(),
+            Payload {
+                msg: blob,
+                aad: &aad,
+            },
+        )
+        .map_err(|_| std_err!("decryption failed - wrong password?"))?;
+
+    Ok(decrypted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_derive_key_deterministic() {
+        let password = b"password";
+        let salt = [0x42; 16];
+
+        let key1 = derive_key(password, &salt).unwrap();
+        let key2 = derive_key(password, &salt).unwrap();
+
+        assert_eq!(
+            key1.as_slice(),
+            key2.as_slice(),
+            "same inputs should produce same key"
+        );
+    }
+
+    #[test]
+    fn test_derive_key_different_passwords() {
+        let salt = [0x42; 16];
+
+        let key1 = derive_key(b"password1", &salt).unwrap();
+        let key2 = derive_key(b"password2", &salt).unwrap();
+
+        assert_ne!(
+            key1.as_slice(),
+            key2.as_slice(),
+            "different passwords should produce different keys"
+        );
+    }
+
+    #[test]
+    fn test_derive_key_different_salts() {
+        let password = b"password";
+
+        let key1 = derive_key(password, &[0x42; 16]).unwrap();
+        let key2 = derive_key(password, &[0x99; 16]).unwrap();
+
+        assert_ne!(
+            key1.as_slice(),
+            key2.as_slice(),
+            "different salts should produce different keys"
+        );
+    }
+
+    #[test]
+    fn test_derive_key_length() {
+        let key = derive_key(b"password", &[0x42; 16]).unwrap();
+        assert_eq!(key.len(), KEY_LEN, "key should be correct length");
+    }
+
+    #[test]
+    fn test_derive_key_empty_password() {
+        let key = derive_key(b"", &[0x42; 16]).unwrap();
+        assert_eq!(key.len(), KEY_LEN, "should handle empty password");
+    }
+
+    #[test]
+    fn test_encrypt_succeeds() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+        let password = b"password";
+
+        let result = encrypt(&mut header, plaintext, password);
+        assert!(result.is_ok(), "encryption should succeed");
+        let ciphertext = encrypt(&mut header, plaintext, password).unwrap();
+        assert_ne!(
+            ciphertext.as_slice(),
+            plaintext,
+            "ciphertext should differ from plaintext"
+        );
+    }
+
+    #[test]
+    fn test_encrypt_populates_header() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+        let password = b"password";
+
+        let salt_before = header.argon_salt;
+        let nonce_before = header.xchacha_nonce;
+
+        encrypt(&mut header, plaintext, password).unwrap();
+
+        assert_ne!(header.argon_salt, salt_before, "salt should be randomized");
+        assert_ne!(
+            header.xchacha_nonce, nonce_before,
+            "nonce should be randomized"
+        );
+    }
+
+    #[test]
+    fn test_encrypt_nonce_randomness() {
+        let plaintext = b"test data";
+        let password = b"password";
+
+        let mut header1 = EnvelopeFileHeader::default();
+        let ciphertext1 = encrypt(&mut header1, plaintext, password).unwrap();
+
+        let mut header2 = EnvelopeFileHeader::default();
+        let ciphertext2 = encrypt(&mut header2, plaintext, password).unwrap();
+
+        assert_ne!(
+            ciphertext1, ciphertext2,
+            "multiple encryptions should produce different outputs"
+        );
+        assert_ne!(
+            header1.xchacha_nonce, header2.xchacha_nonce,
+            "nonces should be different"
+        );
+    }
+
+    #[test]
+    fn test_encrypt_empty_data() {
+        let mut header = EnvelopeFileHeader::default();
+        let result = encrypt(&mut header, &[], b"password");
+
+        assert!(result.is_ok(), "should encrypt empty data");
+        assert!(
+            !result.unwrap().is_empty(),
+            "ciphertext should include auth tag"
+        );
+    }
+
+    #[test]
+    fn test_encrypt_unicode_password() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+        let password = "pâsswörd🔐".as_bytes();
+
+        let result = encrypt(&mut header, plaintext, password);
+        assert!(result.is_ok(), "should handle unicode password");
+    }
+
+    #[test]
+    fn test_decrypt_wrong_password() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+
+        let ciphertext = encrypt(&mut header, plaintext, b"password").unwrap();
+        let result = decrypt(&ciphertext, &header, b"wrong");
+
+        assert!(result.is_err(), "should fail with wrong password");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("decryption failed"),
+            "should indicate decryption failure"
+        );
+    }
+
+    #[test]
+    fn test_decrypt_unsupported_version() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+
+        let ciphertext = encrypt(&mut header, plaintext, b"password").unwrap();
+        header.version = 99;
+
+        let result = decrypt(&ciphertext, &header, b"password");
+
+        assert!(result.is_err(), "should fail with unsupported version");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("unsupported envelope version"),
+            "should mention version"
+        );
+        assert!(
+            err_msg.contains("99"),
+            "should show unsupported version number"
+        );
+    }
+
+    #[test]
+    fn test_decrypt_corrupted_ciphertext() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+
+        let mut ciphertext = encrypt(&mut header, plaintext, b"password").unwrap();
+        assert!(!ciphertext.is_empty());
+
+        let mid = ciphertext.len() / 2;
+        ciphertext[mid] ^= 0xFF;
+
+        let result = decrypt(&ciphertext, &header, b"password");
+        assert!(result.is_err(), "should fail with corrupted ciphertext");
+    }
+
+    #[test]
+    fn test_decrypt_wrong_salt() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+
+        let ciphertext = encrypt(&mut header, plaintext, b"password").unwrap();
+        header.argon_salt[0] ^= 0xFF;
+
+        let result = decrypt(&ciphertext, &header, b"password");
+        assert!(result.is_err(), "should fail with tampered salt");
+    }
+
+    #[test]
+    fn test_decrypt_wrong_nonce() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+
+        let ciphertext = encrypt(&mut header, plaintext, b"password").unwrap();
+        header.xchacha_nonce[0] ^= 0xFF;
+
+        let result = decrypt(&ciphertext, &header, b"password");
+        assert!(result.is_err(), "should fail with tampered nonce");
+    }
+
+    #[test]
+    fn test_decrypt_tampered_magic_in_aad() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+
+        let ciphertext = encrypt(&mut header, plaintext, b"password").unwrap();
+        header.magic_number[0] ^= 0xFF;
+
+        let result = decrypt(&ciphertext, &header, b"password");
+        assert!(
+            result.is_err(),
+            "should fail with tampered magic (AAD binding)"
+        );
+    }
+
+    #[test]
+    fn test_decrypt_empty_ciphertext() {
+        let header = EnvelopeFileHeader::default();
+        let result = decrypt(&[], &header, b"password");
+
+        assert!(result.is_err(), "should fail with empty ciphertext");
+    }
+
+    #[test]
+    fn test_decrypt_truncated_ciphertext() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+
+        let mut ciphertext = encrypt(&mut header, plaintext, b"password").unwrap();
+        ciphertext.truncate(5);
+
+        let result = decrypt(&ciphertext, &header, b"password");
+        assert!(result.is_err(), "should fail with truncated ciphertext");
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+        let password = b"password";
+
+        let ciphertext = encrypt(&mut header, plaintext, password).unwrap();
+        let decrypted = decrypt(&ciphertext, &header, password).unwrap();
+
+        assert_eq!(
+            decrypted.as_slice(),
+            plaintext,
+            "roundtrip should preserve data"
+        );
+    }
+
+    #[test]
+    fn test_roundtrip_empty_data() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = &[];
+        let password = b"password";
+
+        let ciphertext = encrypt(&mut header, plaintext, password).unwrap();
+        let decrypted = decrypt(&ciphertext, &header, password).unwrap();
+
+        assert_eq!(decrypted.as_slice(), plaintext, "should handle empty data");
+    }
+
+    #[test]
+    fn test_roundtrip_binary_data() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext: Vec<u8> = (0u8..=255).collect();
+        let password = b"password";
+
+        let ciphertext = encrypt(&mut header, &plaintext, password).unwrap();
+        let decrypted = decrypt(&ciphertext, &header, password).unwrap();
+
+        assert_eq!(decrypted, plaintext, "should preserve all byte values");
+    }
+
+    #[test]
+    fn test_roundtrip_large_data() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = vec![0x42; 1024 * 1024]; // 1 MB
+        let password = b"password";
+
+        let ciphertext = encrypt(&mut header, &plaintext, password).unwrap();
+        let decrypted = decrypt(&ciphertext, &header, password).unwrap();
+
+        assert_eq!(decrypted, plaintext, "should handle large data");
+    }
+
+    #[test]
+    fn test_roundtrip_unicode_password() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = b"test data";
+        let password = "pâsswörd🔐".as_bytes();
+
+        let ciphertext = encrypt(&mut header, plaintext, password).unwrap();
+        let decrypted = decrypt(&ciphertext, &header, password).unwrap();
+
+        assert_eq!(
+            decrypted.as_slice(),
+            plaintext,
+            "should handle unicode password"
+        );
+    }
+
+    #[test]
+    fn test_multiple_roundtrips() {
+        let original = b"test data";
+        let password = b"password";
+
+        let mut header1 = EnvelopeFileHeader::default();
+        let ciphertext1 = encrypt(&mut header1, original, password).unwrap();
+        let decrypted1 = decrypt(&ciphertext1, &header1, password).unwrap();
+
+        let mut header2 = EnvelopeFileHeader::default();
+        let ciphertext2 = encrypt(&mut header2, &decrypted1, password).unwrap();
+        let decrypted2 = decrypt(&ciphertext2, &header2, password).unwrap();
+
+        assert_eq!(
+            decrypted2.as_slice(),
+            original,
+            "multiple roundtrips should preserve data"
+        );
+    }
+
+    #[test]
+    fn test_roundtrip_single_byte() {
+        let mut header = EnvelopeFileHeader::default();
+        let plaintext = &[0x42u8];
+        let password = b"password";
+
+        let ciphertext = encrypt(&mut header, plaintext, password).unwrap();
+        let decrypted = decrypt(&ciphertext, &header, password).unwrap();
+
+        assert_eq!(decrypted.as_slice(), plaintext, "should handle single byte");
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,0 +1,45 @@
+pub(crate) mod crypto;
+pub mod state;
+
+use std::env;
+use std::io::Result;
+use std::path::PathBuf;
+
+use crate::core::state::UnlockedEnvelope;
+use crate::db::EnvelopeDb;
+use crate::std_err;
+
+const ENVELOPE_FILENAME: &str = ".envelope";
+const ENVELOPE_FILENAME_TMP: &str = ".envelope.tmp";
+
+/// Returns the path to the .envelope file in the current directory
+pub(crate) fn envelope_path() -> Result<PathBuf> {
+    Ok(env::current_dir()?.join(ENVELOPE_FILENAME))
+}
+
+/// Returns the path to the temporary .envelope file
+pub(crate) fn envelope_tmp_path() -> Result<PathBuf> {
+    Ok(env::current_dir()?.join(ENVELOPE_FILENAME_TMP))
+}
+
+/// Initializes a new envelope database.
+///
+/// Creates the .envelope SQLite database file and runs migrations.
+/// Consumes self and returns an UnlockedEnvelope on success.
+pub async fn init() -> Result<UnlockedEnvelope> {
+    let path = envelope_path()?;
+    let db_path = path
+        .to_str()
+        .ok_or_else(|| std_err!("invalid path encoding"))?;
+
+    let pool = sqlx::sqlite::SqlitePool::connect(&format!("sqlite://{}?mode=rwc", db_path))
+        .await
+        .map_err(|e| std_err!("failed to create database: {}", e))?;
+
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .map_err(|e| std_err!("failed to run migrations: {}", e))?;
+
+    Ok(UnlockedEnvelope::with_db(EnvelopeDb::with(pool)))
+}

--- a/src/core/state/locked.rs
+++ b/src/core/state/locked.rs
@@ -1,0 +1,40 @@
+use std::fs;
+use std::io::Result;
+
+use crate::core::crypto::decrypt;
+use crate::core::crypto::header::EnvelopeFileHeader;
+use crate::core::{envelope_path, envelope_tmp_path};
+
+/// Represents a locked (encrypted) envelope.
+///
+/// Contains the encrypted ciphertext and header information needed for decryption.
+#[derive(Debug)]
+pub struct LockedEnvelope {
+    header: EnvelopeFileHeader,
+    ciphertext: Vec<u8>,
+}
+
+impl LockedEnvelope {
+    pub(crate) fn new(header: EnvelopeFileHeader, ciphertext: Vec<u8>) -> Self {
+        Self { header, ciphertext }
+    }
+
+    /// Decrypts the envelope database file.
+    ///
+    /// Reads the encrypted file, decrypts it with the provided password,
+    /// and writes the decrypted SQLite database back to disk using an
+    /// atomic write (temp file + rename).
+    ///
+    /// Consumes self since the envelope is no longer locked after this operation.
+    pub fn unlock(self, password: &str) -> Result<()> {
+        let path = envelope_path()?;
+        let plaintext = decrypt(&self.ciphertext, &self.header, password.as_bytes())?;
+
+        // Atomic write: write to temp file, then rename
+        let tmp_path = envelope_tmp_path()?;
+        fs::write(&tmp_path, &plaintext)?;
+        fs::rename(&tmp_path, &path)?;
+
+        Ok(())
+    }
+}

--- a/src/core/state/mod.rs
+++ b/src/core/state/mod.rs
@@ -1,0 +1,69 @@
+mod locked;
+mod unlocked;
+
+pub use locked::LockedEnvelope;
+pub use unlocked::UnlockedEnvelope;
+
+use std::fs::File;
+use std::io::{Read, Result};
+
+use crate::core::crypto::header::{EnvelopeFileHeader, HEADER_SIZE, MAGIC_NUMBER};
+use crate::core::envelope_path;
+use crate::std_err;
+
+/// sqlite magic number: <https://www.sqlite.org/fileformat.html>
+const SQLITE_MAGIC: &[u8; 16] = b"SQLite format 3\0";
+
+/// Represents the detected state of the envelope file.
+///
+/// The envelope can be in one of two states:
+/// - [`Locked`](Self::Locked): Encrypted with XChaCha20-Poly1305, requires password to access
+/// - [`Unlocked`](Self::Unlocked): Plain SQLite database, ready for use
+#[derive(Debug)]
+pub enum EnvelopeState {
+    /// Envelope is encrypted and requires a password to unlock.
+    Locked(LockedEnvelope),
+    /// Envelope is a plain SQLite database, ready for use.
+    Unlocked,
+}
+
+/// Detects the current state of the envelope file.
+///
+/// This is a synchronous operation that only reads the file header.
+/// Database connection happens separately via `UnlockedEnvelope::open()`.
+pub fn detect() -> Result<Option<EnvelopeState>> {
+    let path = envelope_path()?;
+
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    let mut file = File::open(&path)?;
+    let mut buf = [0u8; HEADER_SIZE];
+    let bytes_read = file.read(&mut buf)?;
+
+    // check for encrypted envelope
+    if bytes_read >= MAGIC_NUMBER.len() && buf.starts_with(MAGIC_NUMBER) {
+        if bytes_read >= HEADER_SIZE
+            && let Ok(header) = EnvelopeFileHeader::try_from(&buf[..])
+        {
+            // valid locked envelope file
+            let mut ciphertext = Vec::new();
+            file.read_to_end(&mut ciphertext)
+                .map_err(|_| std_err!("error reading locked envelope"))?;
+
+            return Ok(Some(EnvelopeState::Locked(LockedEnvelope::new(
+                header, ciphertext,
+            ))));
+        }
+
+        return Err(std_err!("invalid .envelope file"));
+    }
+
+    // check for sqlite database
+    if bytes_read >= SQLITE_MAGIC.len() && buf.starts_with(SQLITE_MAGIC) {
+        return Ok(Some(EnvelopeState::Unlocked));
+    }
+
+    Err(std_err!("invalid .envelope file"))
+}

--- a/src/core/state/unlocked.rs
+++ b/src/core/state/unlocked.rs
@@ -1,0 +1,69 @@
+use std::fs::{self, File};
+use std::io::{Result, Write};
+
+use super::LockedEnvelope;
+use crate::core::crypto::encrypt;
+use crate::core::crypto::header::EnvelopeFileHeader;
+use crate::core::{envelope_path, envelope_tmp_path};
+use crate::db::EnvelopeDb;
+use crate::std_err;
+
+/// Represents an unlocked (unencrypted) envelope with database access.
+pub struct UnlockedEnvelope {
+    pub db: EnvelopeDb,
+}
+
+impl UnlockedEnvelope {
+    /// Opens an existing unlocked envelope database.
+    ///
+    /// This should only be called after `detect()` returns `DetectedEnvelope::Unlocked`.
+    pub async fn open() -> Result<Self> {
+        let path = envelope_path()?;
+        let db_path = path
+            .to_str()
+            .ok_or_else(|| std_err!("invalid path encoding"))?;
+
+        let pool = sqlx::sqlite::SqlitePool::connect(&format!("sqlite://{}?mode=rw", db_path))
+            .await
+            .map_err(|e| std_err!("failed to open database: {}", e))?;
+
+        Ok(Self {
+            db: EnvelopeDb::with(pool),
+        })
+    }
+
+    /// Creates an UnlockedEnvelope with an existing database connection.
+    pub(crate) fn with_db(db: EnvelopeDb) -> Self {
+        Self { db }
+    }
+
+    /// Encrypts the envelope database file.
+    ///
+    /// Reads the SQLite database, encrypts it with the provided password,
+    /// and writes the encrypted file back to disk using an atomic write
+    /// (temp file + rename).
+    ///
+    /// Consumes self since the database connection is no longer valid after
+    /// the file is encrypted.
+    pub fn lock(self, password: &str) -> Result<LockedEnvelope> {
+        // Close the database connection before reading the file to ensure
+        // all writes are flushed and we read a consistent state.
+        drop(self.db);
+
+        let path = envelope_path()?;
+        let plaintext = fs::read(&path)?;
+
+        let mut header = EnvelopeFileHeader::default();
+        let ciphertext = encrypt(&mut header, &plaintext, password.as_bytes())?;
+
+        // Atomic write: write to temp file, then rename
+        let tmp_path = envelope_tmp_path()?;
+        let mut file = File::create(&tmp_path)?;
+        file.write_all(&header.to_bytes())?;
+        file.write_all(&ciphertext)?;
+        file.sync_all()?;
+        fs::rename(&tmp_path, &path)?;
+
+        Ok(LockedEnvelope::new(header, ciphertext))
+    }
+}

--- a/src/db/model.rs
+++ b/src/db/model.rs
@@ -1,0 +1,77 @@
+use sqlx::sqlite::SqliteRow;
+use sqlx::{FromRow, Row};
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct Environment {
+    pub env: String,
+}
+
+#[cfg(test)]
+impl Environment {
+    pub(crate) fn from(e: &str) -> Self {
+        Self { env: e.to_owned() }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct EnvironmentRow {
+    pub env: String,
+    pub key: String,
+    pub value: String,
+}
+
+#[cfg(test)]
+impl EnvironmentRow {
+    pub(crate) fn from(e: &str, k: &str, v: &str) -> Self {
+        Self {
+            env: e.to_owned(),
+            key: k.to_owned(),
+            value: v.to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, sqlx::FromRow)]
+pub struct EnvironmentRowNullable {
+    pub env: String,
+    pub key: String,
+    pub value: Option<String>,
+    pub created_at: String,
+}
+
+#[cfg(test)]
+impl EnvironmentRowNullable {
+    pub(crate) fn from(e: &str, k: &str, v: Option<&str>, date: &str) -> Self {
+        Self {
+            env: e.to_owned(),
+            key: k.to_owned(),
+            value: v.map(|x| x.to_owned()),
+            created_at: date.to_owned(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum EnvironmentDiff {
+    InFirst(String, String),
+    InSecond(String, String),
+    Different(String, String, String),
+}
+
+impl FromRow<'_, SqliteRow> for EnvironmentDiff {
+    fn from_row(row: &SqliteRow) -> sqlx::Result<Self> {
+        let (key, value) = (
+            row.try_get::<String, _>("key")?,
+            row.try_get::<String, _>("value")?,
+        );
+
+        let val = match row.try_get::<String, _>("type")?.as_str() {
+            "+" => Self::InFirst(key, value),
+            "-" => Self::InSecond(key, value),
+            "/" => Self::Different(key, value, row.try_get("diff")?),
+            _ => panic!("unknown value"),
+        };
+
+        Ok(val)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,12 @@
 mod command;
+mod core;
 mod db;
 mod editor;
 mod error;
 mod ops;
 mod subproc;
+mod utils;
+
 use std::io::Write;
 
 use clap::Parser;

--- a/src/ops/add.rs
+++ b/src/ops/add.rs
@@ -48,7 +48,7 @@ mod test {
     use std::io::BufReader;
 
     use super::*;
-    use crate::db::{EnvironmentRow, test_db};
+    use crate::db::{model::EnvironmentRow, test_db};
 
     pub fn stdin_input(s: &str) -> BufReader<&[u8]> {
         BufReader::new(s.as_bytes())

--- a/src/ops/diff.rs
+++ b/src/ops/diff.rs
@@ -1,6 +1,6 @@
 use std::io::{Result, Write};
 
-use crate::db::{EnvelopeDb, EnvironmentDiff};
+use crate::db::{EnvelopeDb, model::EnvironmentDiff};
 
 const ANSI_RED: &str = "\x1b[31m";
 const ANSI_GREEN: &str = "\x1b[32m";

--- a/src/ops/edit.rs
+++ b/src/ops/edit.rs
@@ -1,6 +1,6 @@
 use std::io::{BufRead, BufReader, Result, Write};
 
-use crate::db::{EnvelopeDb, EnvironmentRow, Truncate};
+use crate::db::{EnvelopeDb, Truncate, model::EnvironmentRow};
 use crate::editor;
 
 pub struct EditorData {

--- a/src/ops/history.rs
+++ b/src/ops/history.rs
@@ -1,6 +1,6 @@
 use std::io::{Result, Write};
 
-use crate::db::{EnvelopeDb, EnvironmentRowNullable};
+use crate::db::{EnvelopeDb, model::EnvironmentRowNullable};
 
 pub async fn history<W: Write>(
     writer: &mut W,

--- a/src/ops/list.rs
+++ b/src/ops/list.rs
@@ -3,7 +3,10 @@ use std::io::{BufRead, Result, Write};
 
 use prettytable::{Table, row};
 
-use crate::db::{EnvelopeDb, Environment, EnvironmentRow, Truncate};
+use crate::db::{
+    EnvelopeDb, Truncate,
+    model::{Environment, EnvironmentRow},
+};
 use crate::std_err;
 
 pub async fn print_from_stdin() -> Result<()> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,35 @@
+use std::io::Result;
+
+use zeroize::Zeroizing;
+
+use crate::std_err;
+
+/// Prompts for password input.
+///
+/// Returns the password wrapped in `Zeroizing` to ensure it is securely erased
+/// from memory when dropped
+pub(crate) fn prompt_password(prompt: &str) -> Result<Zeroizing<String>> {
+    rpassword::prompt_password(prompt)
+        .map(Zeroizing::new)
+        .map_err(|e| std_err!("failed to read password: {}", e))
+}
+
+/// Prompts for password with confirmation, returns error if they don't match.
+///
+/// Returns the password wrapped in `Zeroizing` to ensure it is securely erased
+/// from memory when dropped
+pub(crate) fn prompt_password_confirm() -> Result<Zeroizing<String>> {
+    let password = prompt_password("Password: ")?;
+
+    if password.is_empty() {
+        return Err(std_err!("password cannot be empty"));
+    }
+
+    let confirm = prompt_password("Confirm password: ")?;
+
+    if *password != *confirm {
+        return Err(std_err!("passwords do not match"));
+    }
+
+    Ok(password)
+}


### PR DESCRIPTION
https://github.com/mattrighetti/envelope/issues/39

Aim of this PR is to introduce two new commands to `lock` and `unlock` envelope.

For this first iteration, I'm only looking to introduce a way to de/encrypt envelope. This means that users will be able to lock the database but won't be able to perform operations on it while it is in its encrypted state. In the future I plan to make all the operations executable even if the database is in an encrypted state.

Example of what this PR will introduce:

```console
$ envelope lock
Enter passphrase: ************
envelope is locked

$ envelope list
error: envelope is locked
```

```console
$ envelope unlock
Enter passphrase: ************

envelope is unlocked

$ envelope list
prod
dev
```