### PR TITLE
chore(dep): bump rsa to 0.9.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
  "lazy_static",
  "libm",
@@ -1232,9 +1232,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
  "const-oid",
  "digest",


### PR DESCRIPTION
This was raised by dependabot, the vulnerability in `rsa` is in the `sqlx` crate


```console
➜  envelope git:(deps/security-update) cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 903 security advisories (from /Users/matt/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (246 crate dependencies)
Crate:     rsa
Version:   0.9.10
Title:     Marvin Attack: potential key recovery through timing sidechannels
Date:      2023-11-22
ID:        RUSTSEC-2023-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0071
Severity:  5.9 (medium)
Solution:  No fixed upgrade is available!
Dependency tree:
rsa 0.9.10
└── sqlx-mysql 0.8.6
    ├── sqlx-macros-core 0.8.6
    │   └── sqlx-macros 0.8.6
    │       └── sqlx 0.8.6
    │           └── envelope 0.5.1
    └── sqlx 0.8.6

error: 1 vulnerability found!
```

envelope does not use `sqlx-mysql` so it's not affected by this.