### PR TITLE
feat: `run` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Commands:
   list       List saved environments and/or their variables
   lock       Encrypt envelope
   revert     Revert environment variable
+  run        Run a command with environment variables from a specific environment
   unlock     Decrypt the envelope
   help       Print this message or the help of the given subcommand(s)
 
@@ -445,6 +446,40 @@ $ envelope revert prod api_key
 > Revert works because envelope keeps a complete history of all changes.
 > You can revert multiple times to go back through the entire history.
 > Use `envelope history` to see all historical values before reverting.
+
+### Run
+Run a command with environment variables from a specific environment
+automatically injected. This avoids the need to manually export variables into
+your shell.
+```console
+$ envelope run dev -- cargo run
+```
+
+You can run any command and its arguments. The -- separator is optional but
+recommended when your command includes its own flags.
+
+If you wish to clear the inherited envs from the parent process, you can use the
+`--isolated` flag and that will make sure only the selected env variables are
+injected in the subprocess.
+
+```console
+$ envelope add prod ENVIRONMENT=prod
+$ envelope run prod env
+PATH=...
+HOME=/Users/matt
+SHELL=/bin/zsh
+ENVIRONMENT=prod
+
+$ envelope run prod --isolated env
+# only PATH is inherited from parent
+PATH=...
+ENVIRONMENT=prod
+```
+
+**Use cases**:
+- Run scripts without polluting your current shell environment.
+- Quickly test different environments against the same command.
+- Use in CI/CD pipelines to wrap execution steps.
 
 ### History
 View the complete history of a variable, including deleted values:

--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -17,6 +17,7 @@ mod history;
 mod import;
 mod list;
 mod revert;
+mod run;
 
 #[derive(Subcommand)]
 #[command(infer_subcommands = true)]
@@ -49,6 +50,8 @@ pub enum EnvelopeCmd {
     Lock,
 
     Revert(revert::Cmd),
+
+    Run(run::Cmd),
 
     /// Decrypt envelope
     Unlock,
@@ -116,6 +119,7 @@ impl EnvelopeCmd {
             Self::History(history) => history.run(db).await,
             Self::List(list) => list.run(db).await,
             Self::Revert(revert) => revert.run(db).await,
+            Self::Run(run) => run.run(db).await,
             Self::Init | Self::Lock | Self::Unlock => unreachable!(),
         }
     }

--- a/src/command/client/run.rs
+++ b/src/command/client/run.rs
@@ -1,0 +1,53 @@
+use std::io::Result;
+
+use clap::Parser;
+
+use crate::db::EnvelopeDb;
+use crate::std_err;
+use crate::subproc::ChildProcess;
+
+#[derive(Parser)]
+pub struct Cmd {
+    /// Environment to use
+    env: String,
+
+    /// Do not inherit variables from the parent shell
+    #[arg(short, long)]
+    isolated: bool,
+
+    /// Command and arguments to run
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, required = true)]
+    args: Vec<String>,
+}
+
+impl Cmd {
+    pub async fn run(&self, db: &EnvelopeDb) -> Result<()> {
+        if !db.env_exists(&self.env).await? {
+            return Err(std_err!("env {} does not exist", self.env));
+        }
+
+        let (command, remaining_args) = self
+            .args
+            .split_first()
+            .ok_or_else(|| std_err!("no command provided"))?;
+
+        let env_vars = db.list_kv_in_env(&self.env).await?;
+
+        let env_refs: Vec<(&str, &str)> = env_vars
+            .iter()
+            .map(|row| (row.key.as_str(), row.value.as_str()))
+            .collect();
+
+        let args_refs: Vec<&str> = remaining_args.iter().map(String::as_str).collect();
+        let status = ChildProcess::new(command, &args_refs, &env_refs)
+            .isolated(self.isolated)
+            .run()
+            .map_err(|_| std_err!("encountered error while executing command."))?;
+
+        if !status.success() {
+            std::process::exit(status.code().unwrap_or(1));
+        }
+
+        Ok(())
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -158,7 +158,6 @@ impl EnvelopeDb {
         Ok(())
     }
 
-    #[cfg(test)]
     /// lists all active variables in an environment
     pub async fn list_kv_in_env(&self, env: &str) -> io::Result<Vec<EnvironmentRow>> {
         self.list_kv_in_env_alt(env, Truncate::None, "da").await

--- a/src/editor.rs
+++ b/src/editor.rs
@@ -41,7 +41,7 @@ pub fn spawn_with(data: &[u8]) -> Result<Vec<u8>> {
 
     let args = &[pb.to_str().unwrap()];
     let cmd = ChildProcess::new(&editor, args, &[]);
-    cmd.run_shell_command()
+    cmd.run()
         .map_err(|e| std_err!("error running child process: {}", e))?;
 
     let mut file = OpenOptions::new().read(true).open(&pb)?;


### PR DESCRIPTION
`run` should allow users to exec commands with the specified env variables set

For example
```console
$ sqlx migrate info
error: the `--database-url` option or the `DATABASE_URL` environment variable must be provided

$ envelope add dev database_url http://pg:pg@localhost:5432/mydb
$ envelope run dev -- sqlx migrate info
20260214000000/installed initial schema

$ envelope run dev sqlx migrate info
20260214000000/installed initial schema
```