### PR TITLE
refactor: errors with anyhow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,6 +435,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 name = "envelope"
 version = "0.7.1"
 dependencies = [
+ "anyhow",
  "argon2",
  "chacha20poly1305",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/mattrighetti/envelope"
 readme = "README.md"
 
 [dependencies]
+anyhow = "1"
 argon2 = "0.5.3"
 chacha20poly1305 = "0.10.1"
 clap = { version = "4", features = ["derive"] }

--- a/src/command/client.rs
+++ b/src/command/client.rs
@@ -1,10 +1,9 @@
-use std::io::Result;
-
+use anyhow::{Result, bail};
 use clap::Subcommand;
 
 use crate::core::state::{EnvelopeState, UnlockedEnvelope};
 use crate::db::EnvelopeDb;
-use crate::{core, ops, std_err, utils};
+use crate::{core, ops, utils};
 
 mod add;
 mod delete;
@@ -66,7 +65,7 @@ impl EnvelopeCmd {
                 core::init().await?;
                 Ok(())
             }
-            (Self::Init, _) => Err(std_err!("envelope is already initialized")),
+            (Self::Init, _) => bail!("envelope is already initialized"),
 
             // unlock: only valid when locked
             (Self::Unlock, Some(EnvelopeState::Locked(env))) => {
@@ -76,7 +75,7 @@ impl EnvelopeCmd {
                 Ok(())
             }
             (Self::Unlock, Some(EnvelopeState::Unlocked)) => {
-                Err(std_err!("envelope is already unlocked"))
+                bail!("envelope is already unlocked")
             }
 
             // lock: only valid when unlocked
@@ -88,7 +87,7 @@ impl EnvelopeCmd {
                 Ok(())
             }
             (Self::Lock, Some(EnvelopeState::Locked(_))) => {
-                Err(std_err!("envelope is already locked"))
+                bail!("envelope is already locked")
             }
 
             // all other commands: only valid when unlocked
@@ -98,9 +97,9 @@ impl EnvelopeCmd {
             }
 
             // error cases
-            (_, None) => Err(std_err!("envelope is not initialized")),
+            (_, None) => bail!("envelope is not initialized, run `envelope init` first"),
             (_, Some(EnvelopeState::Locked(_))) => {
-                Err(std_err!("envelope is locked - run `envelope unlock` first"))
+                bail!("envelope is locked, run `envelope unlock` first")
             }
         }
     }

--- a/src/command/client/add.rs
+++ b/src/command/client/add.rs
@@ -1,9 +1,10 @@
-use std::io::{BufRead, Result, Write};
+use std::io::{BufRead, Write};
 
+use anyhow::{Result, bail};
 use clap::Parser;
 
 use crate::db::EnvelopeDb;
-use crate::{err, ops};
+use crate::ops;
 
 /// Add environment variables to a specific environment
 #[derive(Parser)]
@@ -26,7 +27,7 @@ pub struct Cmd {
 impl Cmd {
     pub async fn run(&self, db: &EnvelopeDb) -> Result<()> {
         if self.stdin && self.value.is_some() {
-            return err!("can't specify a value if you're reading from stdin");
+            bail!("cannot specify both a value argument and --stdin");
         }
 
         let mut value = String::new();

--- a/src/command/client/delete.rs
+++ b/src/command/client/delete.rs
@@ -1,5 +1,4 @@
-use std::io::Result;
-
+use anyhow::Result;
 use clap::Parser;
 
 use crate::db::EnvelopeDb;

--- a/src/command/client/diff.rs
+++ b/src/command/client/diff.rs
@@ -1,5 +1,4 @@
-use std::io::Result;
-
+use anyhow::Result;
 use clap::Parser;
 
 use crate::db::EnvelopeDb;

--- a/src/command/client/drop.rs
+++ b/src/command/client/drop.rs
@@ -1,5 +1,4 @@
-use std::io::Result;
-
+use anyhow::Result;
 use clap::Parser;
 
 use crate::db::EnvelopeDb;

--- a/src/command/client/duplicate.rs
+++ b/src/command/client/duplicate.rs
@@ -1,9 +1,8 @@
-use std::io::Result;
-
+use anyhow::{Result, ensure};
 use clap::Parser;
 
 use crate::db::EnvelopeDb;
-use crate::{err, ops};
+use crate::ops;
 
 /// Create a copy of another environment
 #[derive(Parser)]
@@ -17,9 +16,10 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(&self, db: &EnvelopeDb) -> Result<()> {
-        if self.source == self.target {
-            return err!("cannot duplicate to same environment");
-        }
+        ensure!(
+            self.source != self.target,
+            "source and target environments cannot be the same"
+        );
 
         ops::duplicate(db, &self.source, &self.target).await
     }

--- a/src/command/client/edit.rs
+++ b/src/command/client/edit.rs
@@ -1,5 +1,4 @@
-use std::io::Result;
-
+use anyhow::Result;
 use clap::Parser;
 
 use crate::db::EnvelopeDb;

--- a/src/command/client/history.rs
+++ b/src/command/client/history.rs
@@ -1,5 +1,4 @@
-use std::io::Result;
-
+use anyhow::Result;
 use clap::Parser;
 
 use crate::db::EnvelopeDb;

--- a/src/command/client/import.rs
+++ b/src/command/client/import.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
-use std::io;
-use std::io::{BufRead, BufReader, Result};
+use std::io::{BufRead, BufReader};
 
+use anyhow::Result;
 use clap::Parser;
 
 use crate::db::EnvelopeDb;
@@ -22,14 +22,14 @@ pub struct Cmd {
 impl Cmd {
     pub async fn run(&self, db: &EnvelopeDb) -> Result<()> {
         let reader: Box<dyn BufRead> = match &self.path {
-            None => Box::new(BufReader::new(io::stdin())),
+            None => Box::new(BufReader::new(std::io::stdin())),
             Some(path) => {
                 let f = File::open(path)?;
                 Box::new(BufReader::new(f))
             }
         };
 
-        ops::import(reader, &mut io::stdout(), db, &self.env).await?;
+        ops::import(reader, &mut std::io::stdout(), db, &self.env).await?;
 
         Ok(())
     }

--- a/src/command/client/list.rs
+++ b/src/command/client/list.rs
@@ -1,6 +1,4 @@
-use std::io;
-use std::io::Result;
-
+use anyhow::Result;
 use clap::Parser;
 
 use crate::db::{self, EnvelopeDb};
@@ -57,10 +55,10 @@ pub struct Cmd {
 impl Cmd {
     pub async fn run(&self, db: &EnvelopeDb) -> Result<()> {
         match &self.env {
-            None => ops::list_envs(&mut io::stdout(), db).await?,
+            None => ops::list_envs(&mut std::io::stdout(), db).await?,
             Some(env) => {
                 if !self.pretty_print {
-                    ops::list_raw(&mut io::stdout(), db, env, self.sort.to_str()).await?;
+                    ops::list_raw(&mut std::io::stdout(), db, env, self.sort.to_str()).await?;
                 } else {
                     let truncate = match self.truncate {
                         true => db::Truncate::Max(60),

--- a/src/command/client/revert.rs
+++ b/src/command/client/revert.rs
@@ -1,5 +1,4 @@
-use std::io::Result;
-
+use anyhow::Result;
 use clap::Parser;
 
 use crate::db::EnvelopeDb;

--- a/src/core/state/locked.rs
+++ b/src/core/state/locked.rs
@@ -1,5 +1,6 @@
 use std::fs;
-use std::io::Result;
+
+use anyhow::Result;
 
 use crate::core::crypto::decrypt;
 use crate::core::crypto::header::EnvelopeFileHeader;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,0 @@
-#[macro_export]
-macro_rules! std_err {
-    ($($tt:tt)*) => { std::io::Error::new(std::io::ErrorKind::Other, format!($($tt)*)) }
-}
-
-#[macro_export]
-macro_rules! err {
-    ($($tt:tt)*) => { Err(std::io::Error::new(std::io::ErrorKind::Other, format!($($tt)*))) }
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ mod command;
 mod core;
 mod db;
 mod editor;
-mod error;
 mod ops;
 mod subproc;
 mod utils;
@@ -35,7 +34,7 @@ struct Envelope {
 
 impl Envelope {
     #[tokio::main(flavor = "current_thread")]
-    async fn run(self) -> std::io::Result<()> {
+    async fn run(self) -> anyhow::Result<()> {
         if let Some(cmd) = self.envelope {
             cmd.run().await?
         } else if !io::stdin().is_terminal() {
@@ -48,11 +47,9 @@ impl Envelope {
     }
 }
 
-fn main() -> std::io::Result<()> {
+fn main() {
     if let Err(err) = Envelope::parse().run() {
-        writeln!(std::io::stderr(), "error: {}", err)?;
+        _ = writeln!(std::io::stderr(), "error: {err}");
         std::process::exit(1);
     }
-
-    Ok(())
 }

--- a/src/ops/add.rs
+++ b/src/ops/add.rs
@@ -1,15 +1,14 @@
-use std::io::{BufRead, Result, Write};
+use std::io::{BufRead, Write};
+
+use anyhow::{Result, ensure};
 
 use crate::db::EnvelopeDb;
-use crate::err;
 
 /// Adds a single key-value element to the database
 ///
 /// If the value of v is None, an empty string is inserted
 pub async fn add_var(db: &EnvelopeDb, env: &str, k: &str, v: &str) -> Result<()> {
-    if k.starts_with('#') {
-        return err!("key name cannot start with #");
-    }
+    ensure!(!k.starts_with('#'), "variable name cannot start with '#'");
 
     db.insert(env, k, v).await?;
 
@@ -29,14 +28,14 @@ pub async fn import<W: Write, R: BufRead>(
 
         let line = line.unwrap();
         if line.starts_with('#') {
-            writeln!(writer, "skipping {}", line)?;
+            writeln!(writer, "skipping {line}")?;
             continue;
         }
 
         if let Some((k, v)) = line.split_once('=') {
             db.insert(env, k, v).await?;
         } else {
-            writeln!(writer, "invalid {}, skipping", line)?;
+            writeln!(writer, "invalid {line}, skipping")?;
         }
     }
 

--- a/src/ops/check.rs
+++ b/src/ops/check.rs
@@ -1,12 +1,14 @@
 use std::collections::HashSet;
-use std::io::{Result, Write};
+use std::io::Write;
+
+use anyhow::Result;
 
 use crate::db::EnvelopeDb;
 
 pub async fn check<W: Write>(w: &mut W, db: &EnvelopeDb) -> Result<()> {
     let res = check_active_envs(db).await?;
     for env in res {
-        writeln!(w, "{}", env)?;
+        writeln!(w, "{env}")?;
     }
 
     Ok(())

--- a/src/ops/delete.rs
+++ b/src/ops/delete.rs
@@ -1,4 +1,4 @@
-use std::io::Result;
+use anyhow::Result;
 
 use crate::db::EnvelopeDb;
 

--- a/src/ops/diff.rs
+++ b/src/ops/diff.rs
@@ -1,4 +1,6 @@
-use std::io::{Result, Write};
+use std::io::Write;
+
+use anyhow::Result;
 
 use crate::db::EnvelopeDb;
 use crate::db::model::EnvironmentDiff;
@@ -13,13 +15,13 @@ pub async fn diff<W: Write>(writer: &mut W, db: &EnvelopeDb, env1: &str, env2: &
     for diff in diffs {
         match diff {
             EnvironmentDiff::InFirst(k, v) => {
-                writeln!(writer, "{ANSI_GREEN}+ {}={}{ANSI_DEFAULT}", k, v)?;
+                writeln!(writer, "{ANSI_GREEN}+ {k}={v}{ANSI_DEFAULT}")?;
             }
             EnvironmentDiff::InSecond(k, v) => {
-                writeln!(writer, "{ANSI_RED}- {}={}{ANSI_DEFAULT}", k, v)?;
+                writeln!(writer, "{ANSI_RED}- {k}={v}{ANSI_DEFAULT}")?;
             }
             EnvironmentDiff::Different(k, v1, v2) => {
-                writeln!(writer, "{ANSI_GRAY}/ {}={} -> {}{ANSI_DEFAULT}", k, v1, v2)?;
+                writeln!(writer, "{ANSI_GRAY}/ {k}={v1} -> {v2}{ANSI_DEFAULT}")?;
             }
         }
     }

--- a/src/ops/drop.rs
+++ b/src/ops/drop.rs
@@ -1,4 +1,4 @@
-use std::io::Result;
+use anyhow::Result;
 
 use crate::db::EnvelopeDb;
 

--- a/src/ops/duplicate.rs
+++ b/src/ops/duplicate.rs
@@ -1,4 +1,4 @@
-use std::io::Result;
+use anyhow::Result;
 
 use crate::db::EnvelopeDb;
 

--- a/src/ops/edit.rs
+++ b/src/ops/edit.rs
@@ -1,4 +1,6 @@
-use std::io::{BufRead, BufReader, Result, Write};
+use std::io::{BufRead, BufReader, Write};
+
+use anyhow::Result;
 
 use crate::db::model::EnvironmentRow;
 use crate::db::{EnvelopeDb, Truncate};

--- a/src/ops/history.rs
+++ b/src/ops/history.rs
@@ -1,4 +1,6 @@
-use std::io::{Result, Write};
+use std::io::Write;
+
+use anyhow::Result;
 
 use crate::db::EnvelopeDb;
 use crate::db::model::EnvironmentRowNullable;
@@ -18,9 +20,9 @@ pub async fn history<W: Write>(
     } in kvs
     {
         if let Some(value) = value {
-            writeln!(writer, "{} {}={}", created_at, key, value)?;
+            writeln!(writer, "{created_at} {key}={value}")?;
         } else {
-            writeln!(writer, "{} {} inactive", created_at, key)?;
+            writeln!(writer, "{created_at} {key} inactive")?;
         }
     }
 

--- a/src/ops/revert.rs
+++ b/src/ops/revert.rs
@@ -1,4 +1,4 @@
-use std::io::Result;
+use anyhow::Result;
 
 use crate::db::EnvelopeDb;
 

--- a/src/subproc.rs
+++ b/src/subproc.rs
@@ -1,6 +1,6 @@
 use std::process::{Command, ExitStatus};
 
-use crate::std_err;
+use anyhow::{Context, Result};
 
 pub struct ChildProcess<'a> {
     command: &'a str,
@@ -24,7 +24,7 @@ impl<'a> ChildProcess<'a> {
         self
     }
 
-    pub fn run(&self) -> Result<ExitStatus, Box<dyn std::error::Error>> {
+    pub fn run(&self) -> Result<ExitStatus> {
         let mut cmd = Command::new(self.command);
 
         if self.isolated {
@@ -41,7 +41,7 @@ impl<'a> ChildProcess<'a> {
 
         let mut child = cmd
             .spawn()
-            .map_err(|e| std_err!("failed to spawn {}: {}", self.command, e))?;
+            .with_context(|| format!("failed to run '{}'", self.command))?;
 
         Ok(child.wait()?)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,5 @@
-use std::io::Result;
-
+use anyhow::{Context, Result, ensure};
 use zeroize::Zeroizing;
-
-use crate::std_err;
 
 /// Prompts for password input.
 ///
@@ -11,7 +8,7 @@ use crate::std_err;
 pub(crate) fn prompt_password(prompt: &str) -> Result<Zeroizing<String>> {
     rpassword::prompt_password(prompt)
         .map(Zeroizing::new)
-        .map_err(|e| std_err!("failed to read password: {}", e))
+        .context("failed to read password")
 }
 
 /// Prompts for password with confirmation, returns error if they don't match.
@@ -21,15 +18,11 @@ pub(crate) fn prompt_password(prompt: &str) -> Result<Zeroizing<String>> {
 pub(crate) fn prompt_password_confirm() -> Result<Zeroizing<String>> {
     let password = prompt_password("Password: ")?;
 
-    if password.is_empty() {
-        return Err(std_err!("password cannot be empty"));
-    }
+    ensure!(!password.is_empty(), "password cannot be empty");
 
     let confirm = prompt_password("Confirm password: ")?;
 
-    if *password != *confirm {
-        return Err(std_err!("passwords do not match"));
-    }
+    ensure!(*password == *confirm, "passwords do not match");
 
     Ok(password)
 }


### PR DESCRIPTION
Too many `.map_err` and `std_err!` in the codebase, `anyhow` should do a better job